### PR TITLE
feat: ACNA-2363- add skip dependencies option

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,11 @@
 {
-  "extends": "@adobe/eslint-config-aio-lib-config"
+  "extends": "@adobe/eslint-config-aio-lib-config",
+  "settings": {
+      "jsdoc": {
+          "ignorePrivate": true
+      }
+  },
+  "parserOptions": {
+      "ecmaVersion": "latest"
+  }
 }

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,4 +1,4 @@
-© Copyright 2015-2022 Adobe. All rights reserved.
+© Copyright 2015-2023 Adobe. All rights reserved.
 
 Adobe holds the copyright for all the files found in this repository.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- 
-Copyright 2022 Adobe. All rights reserved.
+Copyright 2023 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -43,6 +43,8 @@ steps:
     dependencies-to-update-version-tag: next
     # the package name to publish to (optional)
     package-name: @adobe/my-cli-next
+    # the package name to publish to (optional)
+    skip-dependencies-to-update: false
 
 # your package.json version should be transformed after the previous step
 - run: cat package.json

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ steps:
     dependencies-to-update-version-tag: next
     # the package name to publish to (optional)
     package-name: @adobe/my-cli-next
-    # the package name to publish to (optional)
+    # boolean whether to skip dependencies-to-update (optional)
     skip-dependencies-to-update: false
 
 # your package.json version should be transformed after the previous step

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 Adobe. All rights reserved.
+# Copyright 2023 Adobe. All rights reserved.
 # This file is licensed to you under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License. You may obtain a copy
 # of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -32,6 +32,10 @@ inputs:
   package-name:
     description: 'the new package name to publish to'
     required: false
+  skip-dependencies-to-update:
+    description: 'skip updating any =dependencies to update (see dependencies-to-update setting)'
+    required: false
+    default: false
 
 outputs:
   pre-release-version:

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Adobe. All rights reserved.
+Copyright 2023 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,8 +12,7 @@ governing permissions and limitations under the License.
 module.exports = {
   collectCoverage: true,
   collectCoverageFrom: [
-    'src/**/*.js',
-    '!src/index.js'
+    'src/**/*.js'
   ],
   coverageThreshold: {
     global: {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Adobe. All rights reserved.
+Copyright 2023 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Adobe. All rights reserved.
+Copyright 2023 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -18,6 +18,7 @@ const packageJsonPath = core.getInput('package-json-path')
 const dependenciesToUpdate = core.getInput('dependencies-to-update').trim().split(',').filter(d => d) // filter empty strings
 const dependenciesToUpdateVersionTag = core.getInput('dependencies-to-update-version-tag')
 const packageName = core.getInput('package-name')
+const skipDependenciesToUpdate = core.getInput('skip-dependencies-to-update')
 const shaHash = github.context.sha
 
 core.info(`pre-release-tag - ${preReleaseTag}`)
@@ -26,6 +27,7 @@ core.info(`dependencies-to-update - ${dependenciesToUpdate}`)
 core.info(`dependencies-to-update (length)- ${dependenciesToUpdate ? dependenciesToUpdate.length : 0}`)
 core.info(`dependencies-to-update-version-tag - ${dependenciesToUpdateVersionTag}`)
 core.info(`package-name - ${packageName}`)
+core.info(`skip-dependencies-to-update - ${skipDependenciesToUpdate}`)
 core.info(`shaHash - ${shaHash}`)
 
 const packageJson = getPackageJson(packageJsonPath)
@@ -43,7 +45,7 @@ if (packageName && packageName.trim().length > 0) {
 }
 
 // if there are dependencies to update, update with the dependencies version tag
-if (dependenciesToUpdate.length === 0) {
+if (skipDependenciesToUpdate || dependenciesToUpdate.length === 0) {
   core.info('no dependencies to update')
 } else {
   dependenciesToUpdate.forEach(dep => {

--- a/src/index.js
+++ b/src/index.js
@@ -15,11 +15,15 @@ const { getPackageJson, writePackageJson, generatePrereleaseVersion } = require(
 
 const preReleaseTag = core.getInput('pre-release-tag')
 const packageJsonPath = core.getInput('package-json-path')
-const dependenciesToUpdate = core.getInput('dependencies-to-update').trim().split(',').filter(d => d) // filter empty strings
+let dependenciesToUpdate = core.getInput('dependencies-to-update')
 const dependenciesToUpdateVersionTag = core.getInput('dependencies-to-update-version-tag')
 const packageName = core.getInput('package-name')
 const skipDependenciesToUpdate = core.getInput('skip-dependencies-to-update')
 const shaHash = github.context.sha
+
+if (dependenciesToUpdate) {
+  dependenciesToUpdate = dependenciesToUpdate.trim().split(',').filter(d => d) // filter empty strings
+}
 
 core.info(`pre-release-tag - ${preReleaseTag}`)
 core.info(`package-json-path - ${packageJsonPath}`)

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Adobe. All rights reserved.
+Copyright 2023 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,163 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const core = require('@actions/core')
+const { getPackageJson, writePackageJson, generatePrereleaseVersion } = require('../src/utils')
+
+jest.mock('@actions/core')
+jest.mock('../src/utils')
+
+const PRE_RELEASE_VERSION = '1.0.0-pre.abc'
+const GITHUB_SHA = 'abc123'
+
+const createPackageJson = () => {
+  return {
+    version: '1.0.0',
+    dependencies: {
+      a: '^1.0.0',
+      b: '2.0.0'
+    }
+  }
+}
+
+jest.mock('@actions/github', () => ({
+  context: {
+    sha: GITHUB_SHA
+  }
+}))
+
+beforeEach(() => {
+  getPackageJson.mockClear()
+  core.getInput.mockClear()
+  core.error.mockClear()
+  core.setOutput.mockClear()
+  core.info.mockClear()
+
+  getPackageJson.mockReturnValue(createPackageJson())
+  generatePrereleaseVersion.mockReturnValue(PRE_RELEASE_VERSION)
+})
+
+test('update deps, version, sha, package name', () => {
+  const actionValues = {
+    'dependencies-to-update': 'a,b',
+    'package-json-path': './package.json',
+    'dependencies-to-update-version-tag': 'next',
+    'package-name': 'foo-cli'
+  }
+  core.getInput.mockImplementation((key) => {
+    return actionValues[key]
+  })
+
+  jest.isolateModules(() => {
+    require('../src/index') // run the action
+    const originalPackageJson = createPackageJson()
+    expect(writePackageJson).toHaveBeenCalledWith(
+      actionValues['package-json-path'],
+      JSON.stringify({
+        ...originalPackageJson,
+        dependencies: {
+          a: actionValues['dependencies-to-update-version-tag'],
+          b: actionValues['dependencies-to-update-version-tag']
+        },
+        version: PRE_RELEASE_VERSION,
+        prereleaseSha: GITHUB_SHA,
+        name: actionValues['package-name']
+      }, null, 2)
+    )
+
+    expect(core.setOutput).toHaveBeenCalledWith('pre-release-version', PRE_RELEASE_VERSION)
+  })
+})
+
+test('update deps, version, sha (unknown dep, coverage)', () => {
+  const actionValues = {
+    'dependencies-to-update': 'a,b,c', // c is unknown
+    'package-json-path': './package.json',
+    'dependencies-to-update-version-tag': 'next'
+  }
+  core.getInput.mockImplementation((key) => {
+    return actionValues[key]
+  })
+
+  jest.isolateModules(() => {
+    require('../src/index') // run the action
+    const originalPackageJson = createPackageJson()
+    expect(writePackageJson).toHaveBeenCalledWith(
+      actionValues['package-json-path'],
+      JSON.stringify({
+        ...originalPackageJson,
+        dependencies: {
+          a: actionValues['dependencies-to-update-version-tag'],
+          b: actionValues['dependencies-to-update-version-tag']
+        },
+        version: PRE_RELEASE_VERSION,
+        prereleaseSha: GITHUB_SHA,
+        name: actionValues['package-name']
+      }, null, 2)
+    )
+
+    expect(core.error).toHaveBeenCalledWith('dependency c was not found in the package.json file.')
+    expect(core.setOutput).toHaveBeenCalledWith('pre-release-version', PRE_RELEASE_VERSION)
+  })
+})
+
+test('update version, sha (no deps update)', () => {
+  const actionValues = {
+    'dependencies-to-update': '', // empty deps string
+    'package-json-path': './package.json',
+    'dependencies-to-update-version-tag': 'next'
+  }
+  core.getInput.mockImplementation((key) => {
+    return actionValues[key]
+  })
+
+  jest.isolateModules(() => {
+    require('../src/index') // run the action
+    const originalPackageJson = createPackageJson()
+    expect(writePackageJson).toHaveBeenCalledWith(
+      actionValues['package-json-path'],
+      JSON.stringify({
+        ...originalPackageJson, // original deps
+        version: PRE_RELEASE_VERSION,
+        prereleaseSha: GITHUB_SHA
+      }, null, 2)
+    )
+
+    expect(core.setOutput).toHaveBeenCalledWith('pre-release-version', PRE_RELEASE_VERSION)
+  })
+})
+
+test('update version, sha (skip deps update via input boolean)', () => {
+  const actionValues = {
+    'dependencies-to-update': 'a, b',
+    'skip-dependencies-to-update': true,
+    'package-json-path': './package.json',
+    'dependencies-to-update-version-tag': 'next'
+  }
+  core.getInput.mockImplementation((key) => {
+    return actionValues[key]
+  })
+
+  jest.isolateModules(() => {
+    require('../src/index') // run the action
+    const originalPackageJson = createPackageJson()
+    expect(writePackageJson).toHaveBeenCalledWith(
+      actionValues['package-json-path'],
+      JSON.stringify({
+        ...originalPackageJson, // original deps
+        version: PRE_RELEASE_VERSION,
+        prereleaseSha: GITHUB_SHA
+      }, null, 2)
+    )
+
+    expect(core.setOutput).toHaveBeenCalledWith('pre-release-version', PRE_RELEASE_VERSION)
+  })
+})

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Adobe. All rights reserved.
+Copyright 2023 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
Closes #4 

## Description

Add a boolean `skip-dependencies-to-update` option.

## Motivation and Context

Sometimes you need to do a pre-release without updating your dependencies. Fixes scenario in #4 

## How Has This Been Tested?

added unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
