### PR TITLE
fix: add secrets: inherit to daily workflow

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -8,3 +8,4 @@ on:
 jobs:
   build:
     uses: adobe/aio-reusable-workflows/.github/workflows/daily.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Add `secrets: inherit` to the daily reusable workflow job so repository secrets are passed through to `adobe/aio-reusable-workflows`

## Test plan
- [ ] Verify the daily workflow runs successfully with secrets available

🤖 Generated with [Claude Code](https://claude.com/claude-code)